### PR TITLE
Removed setup-dependent path from loader, add test readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 # AstroWebMaps
 OpenLayers 4.x for planetary mapping
 
+This library provides a method to run Openlayers 4 with planetary mapping conversions,
+it is used in PILOT (pilot.wr.usgs.gov) and Astropedia (astrogeology.usgs.gov/search).
 
-This library provides a method to run Openlayers 4 with planetary mapping conversions. This library is used in PILOT (pilot.wr.usgs.gov) and Astropedia (astrogeology.usgs.gov/search). An example on how to run the code is under the test directory. A single and/or minified version of the library can be built using the Makefile. The good stuff resides on under the js directory. Quick description:
+An example on how to run the code is under the [test](test/) directory. 
+
+A single and/or minified version of the library can be built using the Makefile.
+The good stuff resides on under the js directory.
+
+Quick description:
 
 * js/openlayers - a version of openlayers https://openlayers.org/
 * js/astrowebmaps - source code

--- a/js/astrowebmaps-loader.js
+++ b/js/astrowebmaps-loader.js
@@ -2,16 +2,15 @@
 // for debugging. . . load as separate files
 //
 //
-$.getScript( "/astrowebmaps-git/js/astrowebmaps/Map/AstroMap.js", function( data, textStatus, jqxhr ) {});
-$.getScript( "/astrowebmaps-git/js/astrowebmaps/Console/AstroConsole.js", function( data, textStatus, jqxhr ) {});
-$.getScript( "/astrowebmaps-git/js/astrowebmaps/Map/AstroVector.js", function( data, textStatus, jqxhr ) {});
-$.getScript( "/astrowebmaps-git/js/astrowebmaps/Map/AstroBoundingBox.js", function( data, textStatus, jqxhr ) {});
-$.getScript( "/astrowebmaps-git/js/astrowebmaps/Map/AstroPoi.js", function( data, textStatus, jqxhr ) {});
-$.getScript( "/astrowebmaps-git/js/astrowebmaps/Map/Control/AstroControls.js", function( data, textStatus, jqxhr ) {});
-$.getScript( "/astrowebmaps-git/js/astrowebmaps/Helpers/AstroGeometry.js", function( data, textStatus, jqxhr ) {});
-$.getScript( "/astrowebmaps-git/js/astrowebmaps/Map/Control/ol4-scalelinecontrol.js", function( data, textStatus, jqxhr ) {});
-$.getScript( "/astrowebmaps-git/js/astrowebmaps/Map/Control/ol4-layerswitcher-oo.js", function( data, textStatus, jqxhr ) {});
+$.getScript( "/js/astrowebmaps/Map/AstroMap.js", function( data, textStatus, jqxhr ) {});
+$.getScript( "/js/astrowebmaps/Console/AstroConsole.js", function( data, textStatus, jqxhr ) {});
+$.getScript( "/js/astrowebmaps/Map/AstroVector.js", function( data, textStatus, jqxhr ) {});
+$.getScript( "/js/astrowebmaps/Map/AstroBoundingBox.js", function( data, textStatus, jqxhr ) {});
+$.getScript( "/js/astrowebmaps/Map/AstroPoi.js", function( data, textStatus, jqxhr ) {});
+$.getScript( "/js/astrowebmaps/Map/Control/AstroControls.js", function( data, textStatus, jqxhr ) {});
+$.getScript( "/js/astrowebmaps/Helpers/AstroGeometry.js", function( data, textStatus, jqxhr ) {});
+$.getScript( "/js/astrowebmaps/Map/Control/ol4-scalelinecontrol.js", function( data, textStatus, jqxhr ) {});
+$.getScript( "/js/astrowebmaps/Map/Control/ol4-layerswitcher-oo.js", function( data, textStatus, jqxhr ) {});
 
 // for ol-debug.js
 //$.getScript( "/astrowebmaps-git/js/astrowebmaps/Map/Control/ol4-graticulecontrol.js", function( data, textStatus, jqxhr ) {});
-

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,12 @@
+# Sample code
+
+To see this test page in action, start an HTTP server from the root directory
+of this repository, then open this `test/index.html` page.
+
+If you have Python(3) at hand, you can simply run its built-in server,
+```bash
+$ python -m http.server --directory AstroWebMaps
+Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
+...
+```
+, and you are good to visit http://localhost:8000/test/.


### PR DESCRIPTION
File `astrowebmaps-loader` had this `astrowebmaps-git` path hardcoded, indicative of your (Pilot?) setup structure, but out of the scope of the library (_per se_). 

Since (jQuery/`getScript`) the path where the eventual http server runs from is relevant, added a readme with basic instructions.